### PR TITLE
Fix tomcat version to 7.0.65

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -16,7 +16,7 @@
 # Configuration for the Tomcat container
 ---
 tomcat:
-  version: 7.0.+
+  version: 7.0.65
   repository_root: "{default.repository.root}/tomcat"
 lifecycle_support:
   version: 2.+


### PR DESCRIPTION
Currently, can not download tomcat-7.0.69.tar.gz from Pivotal's S3.
So fix tomcat version to 7.0.65.